### PR TITLE
Add video support for scanner

### DIFF
--- a/lib/scan.js
+++ b/lib/scan.js
@@ -48,4 +48,47 @@ async function scanImage(url) {
     }
 }
 
-module.exports = { scanImage };
+/**
+ * Send a raw image buffer to the configured scanner API.
+ *
+ * @param {Buffer} buffer Image data to scan.
+ * @returns {Promise<Object|null>} Parsed scan result or null when unavailable.
+ */
+async function scanBuffer(buffer) {
+    const { scannerApiUrl, authHeader, multipartField } = scannerConfig.get();
+
+    if (!scannerApiUrl) {
+        console.warn('scannerApiUrl is not set in scanner-config.json. Image scanning disabled.');
+        return null;
+    }
+
+    try {
+        let data;
+        let headers;
+
+        if (multipartField) {
+            const form = new FormData();
+            form.append(multipartField, buffer, 'image');
+            data = form;
+            headers = form.getHeaders();
+        } else {
+            data = buffer;
+            headers = { 'Content-Type': 'application/octet-stream' };
+        }
+
+        if (authHeader) {
+            headers['Authorization'] = authHeader;
+        }
+
+        const scan = await axios.post(scannerApiUrl, data, { headers });
+
+        console.log('Scan result:', JSON.stringify(scan.data, null, 2));
+
+        return scan.data || null;
+    } catch (err) {
+        console.error('Image scan request failed:', err.message);
+        return null;
+    }
+}
+
+module.exports = { scanImage, scanBuffer };

--- a/lib/videoFrameExtractor.js
+++ b/lib/videoFrameExtractor.js
@@ -1,0 +1,34 @@
+const axios = require('axios');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { exec } = require('child_process');
+
+/**
+ * Download a video and extract specific frames.
+ *
+ * @param {string} videoUrl URL of the video file.
+ * @param {number[]} frameNumbers Frame indices to extract.
+ * @returns {Promise<Buffer[]>} Buffers for each extracted frame in order.
+ */
+async function extractFrames(videoUrl, frameNumbers) {
+    const resp = await axios.get(videoUrl, { responseType: 'arraybuffer' });
+    const tmpVideo = path.join(os.tmpdir(), `vid_${Date.now()}_${Math.random().toString(36).slice(2)}.tmp`);
+    fs.writeFileSync(tmpVideo, resp.data);
+    const results = [];
+
+    for (const frame of frameNumbers) {
+        const tmpFrame = path.join(os.tmpdir(), `frame_${Date.now()}_${frame}.jpg`);
+        const cmd = `ffmpeg -y -i "${tmpVideo}" -vf "select=eq(n\\,${frame})" -vframes 1 "${tmpFrame}"`;
+        await new Promise((resolve, reject) => {
+            exec(cmd, (err) => err ? reject(err) : resolve());
+        });
+        results.push(fs.readFileSync(tmpFrame));
+        fs.unlinkSync(tmpFrame);
+    }
+
+    fs.unlinkSync(tmpVideo);
+    return results;
+}
+
+module.exports = { extractFrames };


### PR DESCRIPTION
## Summary
- add a video frame extractor utility using ffmpeg
- allow scanner to accept raw buffers
- extend messageCreate to handle videos and scan frames

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685446bc344c8333aae26c494f0c6df0