### PR TITLE
Improve isImageUrl fallback logic

### DIFF
--- a/lib/urlSanitizer.js
+++ b/lib/urlSanitizer.js
@@ -15,6 +15,29 @@ async function isImageUrl(url) {
         });
 
         const type = response.headers['content-type'];
+        if (typeof type === 'string' && type.startsWith('image/')) {
+            return true;
+        }
+
+        console.warn('HEAD did not indicate image, falling back to GET:', url);
+    } catch (err) {
+        console.warn('HEAD request failed, falling back to GET:', url, err.message);
+    }
+
+    try {
+        const resp = await axios({
+            method: 'GET',
+            url,
+            timeout: 3000,
+            maxRedirects: 2,
+            responseType: 'stream',
+            validateStatus: status => status < 400
+        });
+
+        const type = resp.headers['content-type'];
+        if (resp.data && typeof resp.data.destroy === 'function') {
+            resp.data.destroy();
+        }
         return typeof type === 'string' && type.startsWith('image/');
     } catch (err) {
         console.warn('URL check failed:', url, err.message);


### PR DESCRIPTION
## Summary
- add GET-based fallback when HEAD fails in `isImageUrl`
- warn when using the fallback and keep request lightweight

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68544953701c83339aeded822b943061