### PR TITLE
Refactor moderator review handling

### DIFF
--- a/events/messageReactionAdd.js
+++ b/events/messageReactionAdd.js
@@ -2,10 +2,8 @@
 
 const fs = require('fs');
 const path = require('path');
-const scannerConfig = require('../lib/scannerConfig');
-const { scanImage } = require('../lib/scan');
-const { getFilters } = require('../lib/filterManager');
 const { handlePublicScan } = require('../lib/publicScanHandler');
+const { processFlaggedReview } = require('../lib/modReview');
 
 module.exports = {
     name: 'messageReactionAdd',
@@ -24,64 +22,7 @@ module.exports = {
         const message = reaction.message;
 
         // === Moderator Review ===
-        if (client.flaggedReviews && client.flaggedReviews.has(message.id)) {
-            const review = client.flaggedReviews.get(message.id);
-            const guild = message.guild;
-            let member;
-            try {
-                member = await guild.members.fetch(user.id);
-            } catch {
-                return;
-            }
-
-            const cfg = scannerConfig.get();
-            const isMod = (cfg.moderatorRoleId && member.roles.cache.has(cfg.moderatorRoleId)) ||
-                member.permissions.has('ManageMessages');
-            if (!isMod) return;
-
-            if (emoji === '✅') {
-                await message.reply(`Approved by ${user.tag}`);
-                client.flaggedReviews.delete(message.id);
-            } else if (emoji === '❌') {
-                try {
-                    const channel = await client.channels.fetch(review.channelId);
-                    const msg = await channel.messages.fetch(review.flaggedMessageId);
-                    await msg.delete();
-                    await message.reply(`Deleted by ${user.tag}`);
-                } catch (err) {
-                    await message.reply('Failed to delete message.');
-                }
-                client.flaggedReviews.delete(message.id);
-            } else if (emoji === '🔁') {
-                const data = await scanImage(review.attachmentUrl);
-                if (!data) {
-                    await message.reply('Rescan failed.');
-                } else {
-                    const modules = {};
-                    for (const [key, value] of Object.entries(data)) {
-                        if (key.startsWith('modules.')) {
-                            modules[key.slice(8)] = value;
-                        }
-                    }
-
-                    const rawTags =
-                        modules.deepdanbooru_tags?.tags ||
-                        modules.tagging?.tags ||
-                        modules.image_storage?.metadata?.danbooru_tags ||
-                        modules.image_storage?.metadata?.tags ||
-                        [];
-
-                    const tags = Array.isArray(rawTags) ? rawTags : [];
-                    const tagNames = tags.slice(0, 10)
-                        .map(t => typeof t === 'string' ? t : (t.label || t.name || t.tag))
-                        .filter(t => !!t && t.toLowerCase() !== 'rating:safe');
-                    const tagText = tagNames.join(', ') || '—';
-
-                    await message.reply(`Rescan: ${tagText}`);
-                }
-            }
-            return;
-        }
+        if (await processFlaggedReview(reaction, user, client)) return;
 
         // === Voting-System ===
         const channelId = message.channel.id;

--- a/lib/modReview.js
+++ b/lib/modReview.js
@@ -1,0 +1,80 @@
+// /lib/modReview.js
+
+const scannerConfig = require('./scannerConfig');
+const { scanImage } = require('./scan');
+
+/**
+ * Handle moderator reactions to flagged messages.
+ *
+ * @param {MessageReaction} reaction Reaction object
+ * @param {User} user User who reacted
+ * @param {Client} client Discord client
+ * @returns {Promise<boolean>} Whether the reaction was handled
+ */
+async function processFlaggedReview(reaction, user, client) {
+    const emoji = reaction.emoji.name;
+    const message = reaction.message;
+
+    if (client.flaggedReviews && client.flaggedReviews.has(message.id)) {
+        const review = client.flaggedReviews.get(message.id);
+        const guild = message.guild;
+        let member;
+        try {
+            member = await guild.members.fetch(user.id);
+        } catch {
+            return true;
+        }
+
+        const cfg = scannerConfig.get();
+        const isMod = (cfg.moderatorRoleId && member.roles.cache.has(cfg.moderatorRoleId)) ||
+            member.permissions.has('ManageMessages');
+        if (!isMod) return true;
+
+        if (emoji === '✅') {
+            await message.reply(`Approved by ${user.tag}`);
+            client.flaggedReviews.delete(message.id);
+        } else if (emoji === '❌') {
+            try {
+                const channel = await client.channels.fetch(review.channelId);
+                const msg = await channel.messages.fetch(review.flaggedMessageId);
+                await msg.delete();
+                await message.reply(`Deleted by ${user.tag}`);
+            } catch (err) {
+                await message.reply('Failed to delete message.');
+            }
+            client.flaggedReviews.delete(message.id);
+        } else if (emoji === '🔁') {
+            const data = await scanImage(review.attachmentUrl);
+            if (!data) {
+                await message.reply('Rescan failed.');
+            } else {
+                const modules = {};
+                for (const [key, value] of Object.entries(data)) {
+                    if (key.startsWith('modules.')) {
+                        modules[key.slice(8)] = value;
+                    }
+                }
+
+                const rawTags =
+                    modules.deepdanbooru_tags?.tags ||
+                    modules.tagging?.tags ||
+                    modules.image_storage?.metadata?.danbooru_tags ||
+                    modules.image_storage?.metadata?.tags ||
+                    [];
+
+                const tags = Array.isArray(rawTags) ? rawTags : [];
+                const tagNames = tags.slice(0, 10)
+                    .map(t => typeof t === 'string' ? t : (t.label || t.name || t.tag))
+                    .filter(t => !!t && t.toLowerCase() !== 'rating:safe');
+                const tagText = tagNames.join(', ') || '—';
+
+                await message.reply(`Rescan: ${tagText}`);
+            }
+        }
+        return true;
+    }
+    return false;
+}
+
+module.exports = { processFlaggedReview };
+


### PR DESCRIPTION
## Summary
- factor out flagged review reaction logic into `lib/modReview.js`
- simplify `messageReactionAdd` by calling the new helper

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68544d9146bc833392ec84ff18536af4