### PR TITLE
Refactor voting logic into utils

### DIFF
--- a/events/messageReactionAdd.js
+++ b/events/messageReactionAdd.js
@@ -1,9 +1,8 @@
 // /events/messageReactionAdd.js
 
-const fs = require('fs');
-const path = require('path');
 const { handlePublicScan } = require('../lib/publicScanHandler');
 const { processFlaggedReview } = require('../lib/modReview');
+const { addVote } = require('../lib/voteUtils');
 
 module.exports = {
     name: 'messageReactionAdd',
@@ -29,25 +28,8 @@ module.exports = {
         const event = client.activeEvents && client.activeEvents.get(channelId);
         if (event) {
             const entry = event.entries.find(e => e.messageId === message.id);
-            if (entry) {
-                if (!['?', '❓', '✅', '❌', '🔁'].includes(emoji)) {
-                    if (entry.reactionUsers.has(user.id)) return;
-                    entry.reactionUsers.add(user.id);
-
-                    const oldPath = path.join(event.folder, entry.filename);
-                    const newScore = entry.reactionUsers.size;
-                    const newFilename = entry.filename.replace(/_rate\d+_/, `_rate${newScore}_`);
-                    const newPath = path.join(event.folder, newFilename);
-
-                    if (newFilename !== entry.filename) {
-                        try {
-                            fs.renameSync(oldPath, newPath);
-                            entry.filename = newFilename;
-                        } catch (err) {
-                            console.error('Failed to rename file:', err.message);
-                        }
-                    }
-                }
+            if (entry && !['?', '❓', '✅', '❌', '🔁'].includes(emoji)) {
+                addVote(entry, user.id, event);
             }
         }
 

--- a/events/messageReactionRemove.js
+++ b/events/messageReactionRemove.js
@@ -1,5 +1,4 @@
-const fs = require('fs');
-const path = require('path');
+const { removeVote } = require('../lib/voteUtils');
 
 module.exports = {
     name: 'messageReactionRemove',
@@ -21,25 +20,8 @@ module.exports = {
         const event = client.activeEvents && client.activeEvents.get(channelId);
         if (event) {
             const entry = event.entries.find(e => e.messageId === message.id);
-            if (entry) {
-                if (!['?', '❓', '✅', '❌', '🔁'].includes(emoji)) {
-                    if (!entry.reactionUsers.has(user.id)) return;
-                    entry.reactionUsers.delete(user.id);
-
-                    const oldPath = path.join(event.folder, entry.filename);
-                    const newScore = entry.reactionUsers.size;
-                    const newFilename = entry.filename.replace(/_rate\d+_/, `_rate${newScore}_`);
-                    const newPath = path.join(event.folder, newFilename);
-
-                    if (newFilename !== entry.filename) {
-                        try {
-                            fs.renameSync(oldPath, newPath);
-                            entry.filename = newFilename;
-                        } catch (err) {
-                            console.error('Failed to rename file:', err.message);
-                        }
-                    }
-                }
+            if (entry && !['?', '❓', '✅', '❌', '🔁'].includes(emoji)) {
+                removeVote(entry, user.id, event);
             }
         }
     }

--- a/lib/voteUtils.js
+++ b/lib/voteUtils.js
@@ -1,0 +1,50 @@
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Add a vote for an entry and update its filename with the new score.
+ *
+ * @param {Object} entry Entry object containing filename and reactionUsers set
+ * @param {string} userId Discord user ID of the voter
+ * @param {Object} event Event data containing the folder path
+ */
+function addVote(entry, userId, event) {
+    if (!entry || !event || !event.folder) return;
+    if (entry.reactionUsers.has(userId)) return;
+
+    entry.reactionUsers.add(userId);
+    updateFilename(entry, event);
+}
+
+/**
+ * Remove a vote for an entry and update its filename with the new score.
+ *
+ * @param {Object} entry Entry object containing filename and reactionUsers set
+ * @param {string} userId Discord user ID of the voter
+ * @param {Object} event Event data containing the folder path
+ */
+function removeVote(entry, userId, event) {
+    if (!entry || !event || !event.folder) return;
+    if (!entry.reactionUsers.has(userId)) return;
+
+    entry.reactionUsers.delete(userId);
+    updateFilename(entry, event);
+}
+
+function updateFilename(entry, event) {
+    const oldPath = path.join(event.folder, entry.filename);
+    const newScore = entry.reactionUsers.size;
+    const newFilename = entry.filename.replace(/_rate\d+_/, `_rate${newScore}_`);
+    const newPath = path.join(event.folder, newFilename);
+
+    if (newFilename === entry.filename) return;
+
+    try {
+        fs.renameSync(oldPath, newPath);
+        entry.filename = newFilename;
+    } catch (err) {
+        console.error('Failed to rename file:', err.message);
+    }
+}
+
+module.exports = { addVote, removeVote };


### PR DESCRIPTION
## Summary
- factor out vote update steps into `lib/voteUtils.js`
- call new helper functions from reaction handlers

## Testing
- `node --check lib/voteUtils.js`
- `node --check events/messageReactionAdd.js`
- `node --check events/messageReactionRemove.js`


------
https://chatgpt.com/codex/tasks/task_e_68544e667d5c833396f598cf0a4a15ca