### PR TITLE
Use async fs APIs

### DIFF
--- a/events/messageCreate.js
+++ b/events/messageCreate.js
@@ -1,5 +1,5 @@
 const axios = require('axios');
-const fs = require('fs');
+const fs = require('fs/promises');
 const path = require('path');
 const scannerConfig = require('../lib/scannerConfig');
 const { scanImage, scanBuffer } = require('../lib/scan');
@@ -236,7 +236,7 @@ module.exports = {
                     const filename = `${event.name}_${message.author.id}_${message.id}_rate0_${Date.now()}${ext}`;
                     const dest = path.join(event.folder, filename);
                     const imgData = await axios.get(item.url, { responseType: 'arraybuffer' });
-                    fs.writeFileSync(dest, imgData.data);
+                    await fs.writeFile(dest, imgData.data);
 
                     event.entries.push({
                         messageId: message.id,

--- a/events/messageDelete.js
+++ b/events/messageDelete.js
@@ -1,4 +1,4 @@
-const fs = require('fs');
+const fs = require('fs/promises');
 const path = require('path');
 const axios = require('axios');
 const scannerConfig = require('../lib/scannerConfig');
@@ -17,9 +17,7 @@ module.exports = {
         if (!message.attachments || message.attachments.size === 0) return;
 
         const deletedDir = path.join(__dirname, '..', 'deleted');
-        if (!fs.existsSync(deletedDir)) {
-            fs.mkdirSync(deletedDir, { recursive: true });
-        }
+        await fs.mkdir(deletedDir, { recursive: true });
 
         const timestamp = Date.now();
 
@@ -29,7 +27,7 @@ module.exports = {
                 const filename = `${message.author.id}_${timestamp}${ext}`;
                 const dest = path.join(deletedDir, filename);
                 const resp = await axios.get(attachment.url, { responseType: 'arraybuffer' });
-                fs.writeFileSync(dest, resp.data);
+                await fs.writeFile(dest, resp.data);
             } catch (err) {
                 console.error('Failed to save deleted attachment:', err.message);
             }

--- a/lib/createStatsJson.js
+++ b/lib/createStatsJson.js
@@ -1,4 +1,4 @@
-const fs = require('fs');
+const fs = require('fs/promises');
 const path = require('path');
 
 /**
@@ -8,7 +8,7 @@ const path = require('path');
  * @param {Object} client Discord client instance (unused but kept for future extensions).
  * @returns {Object|null} Collected statistics or null on error.
  */
-module.exports = function createStatsJson(event, client) {
+module.exports = async function createStatsJson(event, client) {
     if (!event || !event.folder) return null;
 
     try {
@@ -38,7 +38,7 @@ module.exports = function createStatsJson(event, client) {
         stats.entries = entryStats;
 
         const filePath = path.join(event.folder, `${event.name}.json`);
-        fs.writeFileSync(filePath, JSON.stringify(stats, null, 4));
+        await fs.writeFile(filePath, JSON.stringify(stats, null, 4));
 
         return stats;
     } catch (err) {

--- a/lib/videoFrameExtractor.js
+++ b/lib/videoFrameExtractor.js
@@ -1,5 +1,5 @@
 const axios = require('axios');
-const fs = require('fs');
+const fs = require('fs/promises');
 const os = require('os');
 const path = require('path');
 const { exec } = require('child_process');
@@ -14,7 +14,7 @@ const { exec } = require('child_process');
 async function extractFrames(videoUrl, frameNumbers) {
     const resp = await axios.get(videoUrl, { responseType: 'arraybuffer' });
     const tmpVideo = path.join(os.tmpdir(), `vid_${Date.now()}_${Math.random().toString(36).slice(2)}.tmp`);
-    fs.writeFileSync(tmpVideo, resp.data);
+    await fs.writeFile(tmpVideo, resp.data);
     const results = [];
 
     for (const frame of frameNumbers) {
@@ -23,11 +23,11 @@ async function extractFrames(videoUrl, frameNumbers) {
         await new Promise((resolve, reject) => {
             exec(cmd, (err) => err ? reject(err) : resolve());
         });
-        results.push(fs.readFileSync(tmpFrame));
-        fs.unlinkSync(tmpFrame);
+        results.push(await fs.readFile(tmpFrame));
+        await fs.unlink(tmpFrame);
     }
 
-    fs.unlinkSync(tmpVideo);
+    await fs.unlink(tmpVideo);
     return results;
 }
 


### PR DESCRIPTION
## Summary
- avoid event-loop blocking on file system writes
- ensure deleted messages and stats use async fs
- use async fs helpers in video frame extractor

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6854589301608333b6bb57feac5f82bb