### PR TITLE
Refactor public scan cache usage

### DIFF
--- a/lib/publicScanHandler.js
+++ b/lib/publicScanHandler.js
@@ -1,36 +1,14 @@
 // /lib/publicScanHandler.js
 
 const { scanImage } = require('./scan');
-const { evaluateTags, getFilters } = require('./scannerFilter');
+const { evaluateTags } = require('./scannerFilter');
+const { isRecentlyScanned, markScanned } = require('./scanCache');
 const { extractTags } = require('./tagUtils');
 
-// Zwischenspeicher für kürzlich geprüfte Nachrichten
-const scanTimestamps = new Map();
-const TTL = 600 * 1000; // 10 Minuten
-const MAX_ENTRIES = 1000;
-
-// Bereinigung der Cache-Einträge
-function cleanupCache() {
-    const now = Date.now();
-    for (const [id, ts] of scanTimestamps.entries()) {
-        if (now - ts > TTL) {
-            scanTimestamps.delete(id);
-        }
-    }
-    if (scanTimestamps.size > MAX_ENTRIES) {
-        const sorted = [...scanTimestamps.entries()].sort((a, b) => a[1] - b[1]);
-        for (let i = 0; i < sorted.length - MAX_ENTRIES; i++) {
-            scanTimestamps.delete(sorted[i][0]);
-        }
-    }
-}
-
+// Prüft, ob eine Nachricht kürzlich gescannt wurde und setzt sie ggf. im Cache
 function alreadyScanned(messageId) {
-    const ts = scanTimestamps.get(messageId);
-    const now = Date.now();
-    if (ts && now - ts < TTL) return true;
-    scanTimestamps.set(messageId, now);
-    cleanupCache();
+    if (isRecentlyScanned(messageId)) return true;
+    markScanned(messageId);
     return false;
 }
 


### PR DESCRIPTION
## Summary
- reuse cache helpers in public scan handler

## Testing
- `node --check lib/publicScanHandler.js`

------
https://chatgpt.com/codex/tasks/task_e_68545e2f89a0833397e1b6ef41ffdd76