### PR TITLE
Fix extend command when no active events

### DIFF
--- a/commands/extend.js
+++ b/commands/extend.js
@@ -11,6 +11,11 @@ module.exports = {
         }
 
         const activeEvents = client.activeEvents;
+
+        if (!activeEvents) {
+            return message.reply({ content: '❌ Keine aktiven Events vorhanden.', ephemeral: true });
+        }
+
         const entry = [...activeEvents.entries()].find(([, evt]) => evt.name === eventName);
 
         if (!entry) {


### PR DESCRIPTION
## Summary
- check if `client.activeEvents` exists before using `.entries()` in `extend`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685469c0c3808333bc911a2b10cca155