### PR TITLE
Add cleanup logic for ffmpeg frame extraction

### DIFF
--- a/lib/videoFrameExtractor.js
+++ b/lib/videoFrameExtractor.js
@@ -48,19 +48,36 @@ async function runFfmpeg(cmd) {
  */
 async function extractFrames(videoUrl, frameNumbers) {
     const resp = await axios.get(videoUrl, { responseType: 'arraybuffer' });
-    const tmpVideo = path.join(os.tmpdir(), `vid_${Date.now()}_${Math.random().toString(36).slice(2)}.tmp`);
+    const tmpVideo = path.join(
+        os.tmpdir(),
+        `vid_${Date.now()}_${Math.random().toString(36).slice(2)}.tmp`
+    );
     await fs.writeFile(tmpVideo, resp.data);
     const results = [];
-
-    for (const frame of frameNumbers) {
-        const tmpFrame = path.join(os.tmpdir(), `frame_${Date.now()}_${frame}.jpg`);
-        const cmd = `ffmpeg -y -i "${tmpVideo}" -vf "select=eq(n\\,${frame})" -vframes 1 "${tmpFrame}"`;
-        await runFfmpeg(cmd);
-        results.push(await fs.readFile(tmpFrame));
-        await fs.unlink(tmpFrame);
+    let tmpFrame;
+    try {
+        for (const frame of frameNumbers) {
+            tmpFrame = path.join(
+                os.tmpdir(),
+                `frame_${Date.now()}_${frame}.jpg`
+            );
+            const cmd = `ffmpeg -y -i "${tmpVideo}" -vf "select=eq(n\\,${frame})" -vframes 1 "${tmpFrame}"`;
+            try {
+                await runFfmpeg(cmd);
+            } catch (err) {
+                console.error(`ffmpeg failed extracting frame ${frame}:`, err);
+                throw err;
+            }
+            results.push(await fs.readFile(tmpFrame));
+            await fs.unlink(tmpFrame);
+            tmpFrame = null;
+        }
+    } finally {
+        if (tmpFrame) {
+            await fs.unlink(tmpFrame).catch(() => {});
+        }
+        await fs.unlink(tmpVideo).catch(() => {});
     }
-
-    await fs.unlink(tmpVideo);
     return results;
 }
 


### PR DESCRIPTION
## Summary
- ensure temporary files are always removed in `videoFrameExtractor`
- log ffmpeg errors for easier debugging

## Testing
- `node - <<'EOF'
const { extractFrames } = require('./lib/videoFrameExtractor');
(async () => {
  try {
    await extractFrames('invalidpath.mp4', [0]);
  } catch (err) {
    console.log('Extraction failed as expected');
  }
})();
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68546a6f8ebc83338cd57c174ebcca97