### PR TITLE
Expose helper functions for tests

### DIFF
--- a/events/messageCreate.js
+++ b/events/messageCreate.js
@@ -174,9 +174,7 @@ async function handleVideoScan(attachment, message, client) {
     return false;
 }
 
-module.exports = {
-    name: 'messageCreate',
-    async execute(message, client) {
+async function execute(message, client) {
         if (message.author.bot) return;
 
         if (message.content.startsWith('!')) {
@@ -249,6 +247,16 @@ module.exports = {
                     console.error('Failed to save attachment:', err.stack || err.message);
                 }
             }
+
         }
     }
+
+module.exports = {
+    name: 'messageCreate',
+    execute,
+    isImage,
+    isVideo,
+    isMedia,
+    handleScan,
+    handleVideoScan
 };

--- a/lib/publicScanHandler.js
+++ b/lib/publicScanHandler.js
@@ -52,4 +52,8 @@ async function handlePublicScan(message, attachment, client) {
     await message.channel.send(output);
 }
 
-module.exports = { handlePublicScan };
+module.exports = {
+    handlePublicScan,
+    formatDisplay,
+    alreadyScanned
+};

--- a/tests/messageCreateHelpers.test.js
+++ b/tests/messageCreateHelpers.test.js
@@ -1,0 +1,21 @@
+const { isImage, isVideo, isMedia } = require('../events/messageCreate');
+
+describe('messageCreate helpers', () => {
+  test('isImage detects image extensions', () => {
+    expect(isImage({ url: 'http://a/b.JPG' })).toBe(true);
+    expect(isImage({ url: 'file.png' })).toBe(true);
+    expect(isImage({ url: 'file.txt' })).toBe(false);
+  });
+
+  test('isVideo detects video extensions', () => {
+    expect(isVideo({ url: 'movie.MP4' })).toBe(true);
+    expect(isVideo({ url: 'clip.webm' })).toBe(true);
+    expect(isVideo({ url: 'file.png' })).toBe(false);
+  });
+
+  test('isMedia combines image and video checks', () => {
+    expect(isMedia({ url: 'pic.gif' })).toBe(true);
+    expect(isMedia({ url: 'video.avi' })).toBe(true);
+    expect(isMedia({ url: 'doc.pdf' })).toBe(false);
+  });
+});

--- a/tests/publicScanHandler.test.js
+++ b/tests/publicScanHandler.test.js
@@ -1,0 +1,13 @@
+const { formatDisplay } = require('../lib/publicScanHandler');
+
+describe('publicScanHandler formatDisplay', () => {
+  test('safe output with no matches', () => {
+    const out = formatDisplay(0, [], ['cat', 'dog']);
+    expect(out).toBe('🟢 Safe\n**Tags:** cat, dog');
+  });
+
+  test('explicit output highlights matches', () => {
+    const out = formatDisplay(1, ['nudity'], ['nudity', 'cat']);
+    expect(out).toBe('🔞 Explicit\n**Critical tags:** **nudity**\n**Tags:** **nudity**, cat');
+  });
+});


### PR DESCRIPTION
## Summary
- expose `formatDisplay` and `alreadyScanned` from `publicScanHandler`
- export helper functions from `messageCreate` for direct import
- add unit tests for `formatDisplay` and message helper functions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68546e8e31608333ac00d0563db63815