### PR TITLE
Add unit tests for scannerFilter functions

### DIFF
--- a/tests/scannerFilter.test.js
+++ b/tests/scannerFilter.test.js
@@ -4,13 +4,45 @@ jest.mock('fs', () => ({
   writeFileSync: jest.fn()
 }));
 
-const filter = require('../lib/scannerFilter');
+const path = require('path');
+let fs = require('fs');
+let filter;
+
+const filePath = path.join(__dirname, '..', 'scanner-filters.json');
 
 describe('scannerFilter', () => {
-  test('evaluateTags detects filtered tags', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    fs = require('fs');
+    filter = require('../lib/scannerFilter');
+    fs.writeFileSync.mockClear();
+  });
+
+  test('addFilter stores tag and writes to file', () => {
     filter.addFilter(1, 'explicit');
-    const result = filter.evaluateTags(['explicit', 'other']);
-    expect(result).toEqual({ level: 1, matched: ['explicit'] });
-    filter.removeFilter(1, 'explicit');
+    expect(filter.getFilters()['1']).toContain('explicit');
+    expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
+    const [p, data] = fs.writeFileSync.mock.calls[0];
+    expect(p).toBe(filePath);
+    expect(JSON.parse(data)['1']).toContain('explicit');
+  });
+
+  test('removeFilter deletes tag and writes to file', () => {
+    filter.addFilter(2, 'bad');
+    fs.writeFileSync.mockClear();
+    filter.removeFilter(2, 'bad');
+    expect(filter.getFilters()['2']).not.toContain('bad');
+    expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
+    const [p, data] = fs.writeFileSync.mock.calls[0];
+    expect(p).toBe(filePath);
+    expect(JSON.parse(data)['2']).not.toContain('bad');
+  });
+
+  test('evaluateTags returns highest severity match', () => {
+    filter.addFilter(0, 'banned');
+    filter.addFilter(1, 'explicit');
+    fs.writeFileSync.mockClear();
+    const res = filter.evaluateTags(['explicit', 'banned']);
+    expect(res).toEqual({ level: 0, matched: ['banned'] });
   });
 });


### PR DESCRIPTION
## Summary
- extend `scannerFilter.test.js`
- cover `addFilter`, `removeFilter` and more `evaluateTags` scenarios with a mocked filesystem

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854715b33d483339710b1d351bae6a0