### PR TITLE
Add nock-based tests for urlSanitizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ config/ftp.json
 event_files/
 deleted/
 temp/
+logs/
 *.zip
 *.json_old
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "form-data": "^4.0.0"
       },
       "devDependencies": {
-        "jest": "^29.7.0"
+        "jest": "^29.7.0",
+        "nock": "^14.0.5"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -1020,6 +1021,49 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.38.7",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.38.7.tgz",
+      "integrity": "sha512-Jkb27iSn7JPdkqlTqKfhncFfnEZsIJVYxsFbUSWEkxdIPdsyngrhoDBk0/BGD2FQcRH99vlRrkHpNTyKqI+0/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@sapphire/async-queue": {
       "version": "1.5.5",
@@ -2427,6 +2471,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -3178,6 +3229,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -3386,6 +3444,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nock": {
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.5.tgz",
+      "integrity": "sha512-R49fALR9caB6vxuSWUIaK2eBYeTloZQUFBZ4rHO+TbhMGQHtwnhdqKLYki+o+8qMgLvoBYWrp/2KzGPhxL4S6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@mswjs/interceptors": "^0.38.7",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18.20.0 <20 || >=20.12.1"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -3448,6 +3521,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -3645,6 +3725,16 @@
         "node": ">= 6"
       }
     },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -3836,6 +3926,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-length": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "author": "Jens",
   "license": "MIT",
   "devDependencies": {
-    "jest": "^29.7.0"
+    "jest": "^29.7.0",
+    "nock": "^14.0.5"
   }
 }

--- a/tests/urlSanitizer.test.js
+++ b/tests/urlSanitizer.test.js
@@ -1,0 +1,84 @@
+const nock = require('nock');
+const { isImageUrl } = require('../lib/urlSanitizer');
+
+const proxyVars = [
+  'HTTP_PROXY',
+  'http_proxy',
+  'HTTPS_PROXY',
+  'https_proxy',
+  'npm_config_https_proxy',
+  'npm_config_http_proxy',
+  'npm_config_proxy',
+  'no_proxy',
+  'NO_PROXY',
+  'YARN_HTTP_PROXY',
+  'YARN_HTTPS_PROXY'
+];
+
+const savedEnv = {};
+
+function clearProxies() {
+  proxyVars.forEach(v => {
+    savedEnv[v] = process.env[v];
+    delete process.env[v];
+  });
+}
+
+function restoreProxies() {
+  proxyVars.forEach(v => {
+    if (savedEnv[v] !== undefined) process.env[v] = savedEnv[v];
+    else delete process.env[v];
+  });
+}
+
+describe('isImageUrl', () => {
+  beforeAll(() => {
+    clearProxies();
+  });
+
+  afterAll(() => {
+    restoreProxies();
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  test('returns true for valid image URL using HEAD', async () => {
+    nock('http://example.com')
+      .head('/img.jpg')
+      .reply(200, '', { 'Content-Type': 'image/jpeg' });
+
+    const result = await isImageUrl('http://example.com/img.jpg');
+    expect(result).toBe(true);
+    expect(nock.isDone()).toBe(true);
+  });
+
+  test('returns true when HEAD fails but GET succeeds', async () => {
+    nock('http://fallback.com')
+      .head('/pic.png')
+      .replyWithError('network error');
+
+    nock('http://fallback.com')
+      .get('/pic.png')
+      .reply(200, '', { 'Content-Type': 'image/png' });
+
+    const result = await isImageUrl('http://fallback.com/pic.png');
+    expect(result).toBe(true);
+    expect(nock.isDone()).toBe(true);
+  });
+
+  test('returns false for non-image URL', async () => {
+    nock('http://bad.com')
+      .head('/file.txt')
+      .reply(200, '', { 'Content-Type': 'text/plain' });
+
+    nock('http://bad.com')
+      .get('/file.txt')
+      .reply(200, 'nope', { 'Content-Type': 'text/plain' });
+
+    const result = await isImageUrl('http://bad.com/file.txt');
+    expect(result).toBe(false);
+    expect(nock.isDone()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- ignore `logs` directory
- add `nock` dev dependency
- test `isImageUrl` with mocked HEAD/GET requests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685474d45aec833395058c3fa36be0d1