### PR TITLE
Add warning workflow for flagged posts

### DIFF
--- a/events/messageCreate.js
+++ b/events/messageCreate.js
@@ -82,13 +82,15 @@ async function handleScan(attachment, message, client) {
 
                 await summary.react('✅');
                 await summary.react('❌');
+                await summary.react('⚠️');
                 await summary.react('🔁');
 
                 if (!client.flaggedReviews) client.flaggedReviews = new Map();
                 client.flaggedReviews.set(summary.id, {
                     flaggedMessageId: message.id,
                     channelId: message.channel.id,
-                    attachmentUrl: attachment.url
+                    attachmentUrl: attachment.url,
+                    userId: message.author.id
                 });
             }
         }
@@ -156,13 +158,15 @@ async function handleVideoScan(attachment, message, client) {
 
                     await summary.react('✅');
                     await summary.react('❌');
+                    await summary.react('⚠️');
                     await summary.react('🔁');
 
                     if (!client.flaggedReviews) client.flaggedReviews = new Map();
                     client.flaggedReviews.set(summary.id, {
                         flaggedMessageId: message.id,
                         channelId: message.channel.id,
-                        attachmentUrl: attachment.url
+                        attachmentUrl: attachment.url,
+                        userId: message.author.id
                     });
                 }
             }

--- a/lib/modReview.js
+++ b/lib/modReview.js
@@ -43,6 +43,15 @@ async function processFlaggedReview(reaction, user, client) {
                 await message.reply('Failed to delete message.');
             }
             client.flaggedReviews.delete(message.id);
+        } else if (emoji === '⚠️') {
+            try {
+                const flaggedUser = await client.users.fetch(review.userId);
+                await flaggedUser.send('This picture violates our rules and has been flagged by the moderators.');
+                await message.reply(`Warned ${flaggedUser.tag}`);
+            } catch (err) {
+                await message.reply('Failed to send warning.');
+            }
+            client.flaggedReviews.delete(message.id);
         } else if (emoji === '🔁') {
             const data = await scanImage(review.attachmentUrl);
             if (!data) {

--- a/tests/modReview.test.js
+++ b/tests/modReview.test.js
@@ -1,0 +1,39 @@
+const { processFlaggedReview } = require('../lib/modReview');
+
+function createMockReaction() {
+  const reply = jest.fn();
+  const member = {
+    roles: { cache: new Map() },
+    permissions: { has: jest.fn().mockReturnValue(true) }
+  };
+  const guild = { members: { fetch: jest.fn().mockResolvedValue(member) } };
+  const message = { id: 'sum', guild, reply };
+  const reaction = { emoji: { name: '⚠️' }, message };
+  return { reaction, reply, guild };
+}
+
+test('processFlaggedReview warns user via DM', async () => {
+  const { reaction, reply } = createMockReaction();
+  const client = {
+    flaggedReviews: new Map([
+      ['sum', {
+        flaggedMessageId: 'orig',
+        channelId: 'chan',
+        attachmentUrl: 'url',
+        userId: 'target'
+      }]
+    ]),
+    users: { fetch: jest.fn().mockResolvedValue({ send: jest.fn(), tag: 'user#1' }) },
+    channels: { fetch: jest.fn() }
+  };
+  const user = { id: 'mod', tag: 'mod#1' };
+
+  const handled = await processFlaggedReview(reaction, user, client);
+
+  expect(handled).toBe(true);
+  expect(client.users.fetch).toHaveBeenCalledWith('target');
+  const fetched = await client.users.fetch.mock.results[0].value;
+  expect(fetched.send).toHaveBeenCalledWith('This picture violates our rules and has been flagged by the moderators.');
+  expect(reply).toHaveBeenCalledWith('Warned user#1');
+  expect(client.flaggedReviews.size).toBe(0);
+});


### PR DESCRIPTION
## Summary
- include the posting user's ID in flagged review data
- react with an additional ⚠️ emoji on moderator summaries
- send a warning DM when moderators react with ⚠️
- test the new warning branch

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68555c03fb848333bd73b9eb2a767e0d