### PR TITLE
Fix scannerConfig import in handleMessageCreate

### DIFF
--- a/lib/handleMessageCreate.js
+++ b/lib/handleMessageCreate.js
@@ -6,7 +6,7 @@ const { isRecentlyScanned, markScanned } = require('./scanCache');
 const { handleImageScan } = require('./handleImageScan');
 const { handleEventUpload } = require('./handleEventUpload');
 const { handleVideoScan } = require('./handleVideoScan');
-const { getScannerConfig } = require('./scannerConfig');
+const scannerConfig = require('./scannerConfig');
 const axios = require('axios');
 const fs = require('fs');
 const path = require('path');
@@ -30,7 +30,7 @@ async function handleMessageCreate(message, client) {
     const response = await axios.get(attachment.url, { responseType: 'arraybuffer' });
     const buffer = Buffer.from(response.data);
 
-    const config = getScannerConfig();
+    const config = scannerConfig.get();
     let scanResult = null;
 
     if (isVideo) {


### PR DESCRIPTION
## Summary
- use `scannerConfig.get()` when scanning videos

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6856cbc908b08333ae36763648816997